### PR TITLE
Pin Python version in the environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: feedback-cookbook-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
+  - python>=3.12
   - mystmd
   - jupyterlab
   - jupyterlab-myst


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This turns out to be necessary to get a working environment on the 2i2c hub, which is defaulting to Python 3.10 otherwise and leading to some code failures with `intake_esm`